### PR TITLE
Fix error when calling immediately after adding the task definition.

### DIFF
--- a/src/add-to-task-definition.ts
+++ b/src/add-to-task-definition.ts
@@ -64,6 +64,8 @@ export const addMackerelContainerAgent = (
   if (ignoreContainer) {
     environment.MACKEREL_IGNORE_CONTAINER = ignoreContainer
   }
+  const taskHasntDefaultContainer = !taskDefinition.defaultContainer
+
   const mackerelAgentContainer = taskDefinition.addContainer("mackerel-agent", {
     ...opts,
     environment,
@@ -71,6 +73,9 @@ export const addMackerelContainerAgent = (
       "mackerel/mackerel-container-agent:latest"
     ),
   })
+
+  if (taskHasntDefaultContainer) taskDefinition.defaultContainer = undefined
+
   taskDefinition.addVolume({
     host: {
       sourcePath: "/cgroup", // TODO: support AL2


### PR DESCRIPTION
Calling addMackerelContainerAgent immediately after adding the task definition will result in an error.

```
    const taskDefinition = new ecs.Ec2TaskDefinition(this, 'TaskDef')

    addMackerelContainerAgent({
      taskDefinition,
      apiKey: '',
    })
```

```
$ npx cdk diff
Container mackerel-agent hasn't defined any ports. Call addPortMappings().
```

The reason is that mackerel-agent is defaultContainer.
https://awslabs.github.io/aws-cdk/refs/_aws-cdk_aws-ecs.html?highlight=defaultcontainer#@aws-cdk/aws-ecs.Ec2TaskDefinition.defaultContainer