### PR TITLE
Do not mount cgroup / docker.sock when awsVpc or fargate

### DIFF
--- a/src/__snapshots__/mackerel-container-agent-definition.test.ts.snap
+++ b/src/__snapshots__/mackerel-container-agent-definition.test.ts.snap
@@ -196,6 +196,144 @@ Object {
 }
 `;
 
+exports[`MackerelContainerAgentDefinition volumes are not mounted when awsvpc / fargate 1`] = `
+Object {
+  "Resources": Object {
+    "TaskDefinitionAwsVpc90383BD2": Object {
+      "Properties": Object {
+        "ContainerDefinitions": Array [
+          Object {
+            "Environment": Array [
+              Object {
+                "Name": "MACKEREL_APIKEY",
+                "Value": "keep-my-secret",
+              },
+              Object {
+                "Name": "MACKEREL_CONTAINER_PLATFORM",
+                "Value": "ecs_awsvpc",
+              },
+            ],
+            "Essential": true,
+            "Image": "mackerel/mackerel-container-agent:latest",
+            "Links": Array [],
+            "LinuxParameters": Object {
+              "Capabilities": Object {
+                "Add": Array [],
+                "Drop": Array [],
+              },
+              "Devices": Array [],
+              "Tmpfs": Array [],
+            },
+            "MountPoints": Array [],
+            "Name": "mackerel-container-agent-awsvpc",
+            "PortMappings": Array [],
+            "Ulimits": Array [],
+            "VolumesFrom": Array [],
+          },
+        ],
+        "Family": "TaskDefinitionAwsVpc",
+        "NetworkMode": "awsvpc",
+        "PlacementConstraints": Array [],
+        "RequiresCompatibilities": Array [
+          "EC2",
+        ],
+        "TaskRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "TaskDefinitionAwsVpcTaskRole20EF5F40",
+            "Arn",
+          ],
+        },
+        "Volumes": Array [],
+      },
+      "Type": "AWS::ECS::TaskDefinition",
+    },
+    "TaskDefinitionAwsVpcTaskRole20EF5F40": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "TaskDefinitionFargate8CDB15BB": Object {
+      "Properties": Object {
+        "ContainerDefinitions": Array [
+          Object {
+            "Environment": Array [
+              Object {
+                "Name": "MACKEREL_APIKEY",
+                "Value": "keep-my-secret",
+              },
+              Object {
+                "Name": "MACKEREL_CONTAINER_PLATFORM",
+                "Value": "fargate",
+              },
+            ],
+            "Essential": true,
+            "Image": "mackerel/mackerel-container-agent:latest",
+            "Links": Array [],
+            "LinuxParameters": Object {
+              "Capabilities": Object {
+                "Add": Array [],
+                "Drop": Array [],
+              },
+              "Devices": Array [],
+              "Tmpfs": Array [],
+            },
+            "MountPoints": Array [],
+            "Name": "mackerel-container-agent-fargate",
+            "PortMappings": Array [],
+            "Ulimits": Array [],
+            "VolumesFrom": Array [],
+          },
+        ],
+        "Cpu": "256",
+        "Family": "TaskDefinitionFargate",
+        "Memory": "512",
+        "NetworkMode": "awsvpc",
+        "RequiresCompatibilities": Array [
+          "FARGATE",
+        ],
+        "TaskRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "TaskDefinitionFargateTaskRoleD9798C07",
+            "Arn",
+          ],
+        },
+        "Volumes": Array [],
+      },
+      "Type": "AWS::ECS::TaskDefinition",
+    },
+    "TaskDefinitionFargateTaskRoleD9798C07": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+  },
+}
+`;
+
 exports[`MackerelContainerAgentDefinition with roles 1`] = `
 Object {
   "Resources": Object {

--- a/src/mackerel-container-agent-definition.test.ts
+++ b/src/mackerel-container-agent-definition.test.ts
@@ -1,4 +1,8 @@
-import { Ec2TaskDefinition } from "@aws-cdk/aws-ecs"
+import {
+  Ec2TaskDefinition,
+  FargateTaskDefinition,
+  NetworkMode,
+} from "@aws-cdk/aws-ecs"
 import { Stack } from "@aws-cdk/cdk"
 import { MackerelContainerAgentDefinition } from "./mackerel-container-agent-definition"
 
@@ -45,6 +49,39 @@ describe("MackerelContainerAgentDefinition", () => {
         apiKey: "keep-my-secret",
         ignoreContainer: "(mackerel|xray)",
         taskDefinition,
+      }
+    )
+    expect(stack.toCloudFormation()).toMatchSnapshot()
+  })
+
+  test("volumes are not mounted when awsvpc / fargate", () => {
+    const stack = new Stack()
+    const taskDefinitionAwsVpc = new Ec2TaskDefinition(
+      stack,
+      "TaskDefinitionAwsVpc",
+      {
+        networkMode: NetworkMode.AwsVpc,
+      }
+    )
+    const containerAwsVpc = new MackerelContainerAgentDefinition(
+      stack,
+      "mackerel-container-agent-awsvpc",
+      {
+        apiKey: "keep-my-secret",
+        taskDefinition: taskDefinitionAwsVpc,
+      }
+    )
+    const taskDefinitionFargate = new FargateTaskDefinition(
+      stack,
+      "TaskDefinitionFargate",
+      {}
+    )
+    const containerFargate = new MackerelContainerAgentDefinition(
+      stack,
+      "mackerel-container-agent-fargate",
+      {
+        apiKey: "keep-my-secret",
+        taskDefinition: taskDefinitionFargate,
       }
     )
     expect(stack.toCloudFormation()).toMatchSnapshot()

--- a/src/mackerel-container-agent-definition.ts
+++ b/src/mackerel-container-agent-definition.ts
@@ -5,7 +5,7 @@ import {
 } from "@aws-cdk/aws-ecs"
 import { Construct } from "@aws-cdk/cdk"
 import { guessPlatform } from "./guess-platform"
-import { ServiceRole } from "./types"
+import { MackerelContainerPlatform, ServiceRole } from "./types"
 
 export interface Props
   extends Pick<
@@ -57,24 +57,26 @@ export class MackerelContainerAgentDefinition extends ContainerDefinition {
       taskDefinition,
     })
 
-    taskDefinition.addVolume({
-      host: { sourcePath: "/cgroup" }, // TODO: support AL2
-      name: "cgroup",
-    })
-    this.addMountPoints({
-      containerPath: "/host/sys/fs/cgroup",
-      readOnly: true,
-      sourceVolume: "cgroup",
-    })
+    if (guessedPlatform === MackerelContainerPlatform.ECS) {
+      taskDefinition.addVolume({
+        host: { sourcePath: "/cgroup" }, // TODO: support AL2
+        name: "cgroup",
+      })
+      this.addMountPoints({
+        containerPath: "/host/sys/fs/cgroup",
+        readOnly: true,
+        sourceVolume: "cgroup",
+      })
 
-    taskDefinition.addVolume({
-      host: { sourcePath: "/var/run/docker.sock" },
-      name: "docker_sock",
-    })
-    this.addMountPoints({
-      containerPath: "/var/run/docker.sock",
-      readOnly: true,
-      sourceVolume: "docker_sock",
-    })
+      taskDefinition.addVolume({
+        host: { sourcePath: "/var/run/docker.sock" },
+        name: "docker_sock",
+      })
+      this.addMountPoints({
+        containerPath: "/var/run/docker.sock",
+        readOnly: true,
+        sourceVolume: "docker_sock",
+      })
+    }
   }
 }


### PR DESCRIPTION
Hi, thanks for nice package!!

As described in https://mackerel.io/docs/entry/howto/install-agent/container/ecsawsvpc , mounting docker.sock and cgroup is not needed when networking mode is AwsVpc.
Especially, in Fargate those configs emit error because we cannot use `host.sourcePath` in Fargate.

```
 1/4 | 05:08:25 | UPDATE_FAILED        | AWS::ECS::TaskDefinition                    | DiamondReader (DiamondReaderD7E0BB29) host.sourcePath should not be set for volumes in Fargate. (Service: AmazonECS; Status Code: 400; Error Code: ClientException; Request ID: XXX-YYY-ZZZ)
```