### PR TITLE
Support specifying custom image for mackerel-container-agent

### DIFF
--- a/src/__snapshots__/mackerel-container-agent-definition.test.ts.snap
+++ b/src/__snapshots__/mackerel-container-agent-definition.test.ts.snap
@@ -364,6 +364,102 @@ Object {
 }
 `;
 
+exports[`MackerelContainerAgentDefinition EC2 with customImage 1`] = `
+Object {
+  "Resources": Object {
+    "TaskDefinitionB36D86D9": Object {
+      "Properties": Object {
+        "ContainerDefinitions": Array [
+          Object {
+            "Environment": Array [
+              Object {
+                "Name": "MACKEREL_APIKEY",
+                "Value": "keep-my-secret",
+              },
+              Object {
+                "Name": "MACKEREL_CONTAINER_PLATFORM",
+                "Value": "ecs",
+              },
+            ],
+            "Essential": true,
+            "Image": "somebody/some-custom-agent-image",
+            "Links": Array [],
+            "LinuxParameters": Object {
+              "Capabilities": Object {
+                "Add": Array [],
+                "Drop": Array [],
+              },
+              "Devices": Array [],
+              "Tmpfs": Array [],
+            },
+            "MountPoints": Array [
+              Object {
+                "ContainerPath": "/host/sys/fs/cgroup",
+                "ReadOnly": true,
+                "SourceVolume": "cgroup",
+              },
+              Object {
+                "ContainerPath": "/var/run/docker.sock",
+                "ReadOnly": true,
+                "SourceVolume": "docker_sock",
+              },
+            ],
+            "Name": "mackerel-container-agent",
+            "PortMappings": Array [],
+            "Ulimits": Array [],
+            "VolumesFrom": Array [],
+          },
+        ],
+        "Family": "TaskDefinition",
+        "NetworkMode": "bridge",
+        "PlacementConstraints": Array [],
+        "RequiresCompatibilities": Array [
+          "EC2",
+        ],
+        "TaskRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "TaskDefinitionTaskRoleFD40A61D",
+            "Arn",
+          ],
+        },
+        "Volumes": Array [
+          Object {
+            "Host": Object {
+              "SourcePath": "/cgroup",
+            },
+            "Name": "cgroup",
+          },
+          Object {
+            "Host": Object {
+              "SourcePath": "/var/run/docker.sock",
+            },
+            "Name": "docker_sock",
+          },
+        ],
+      },
+      "Type": "AWS::ECS::TaskDefinition",
+    },
+    "TaskDefinitionTaskRoleFD40A61D": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+  },
+}
+`;
+
 exports[`MackerelContainerAgentDefinition EC2 with hostStatusOnStart 1`] = `
 Object {
   "Resources": Object {

--- a/src/mackerel-container-agent-definition.test.ts
+++ b/src/mackerel-container-agent-definition.test.ts
@@ -1,5 +1,6 @@
 import { AmazonLinuxGeneration } from "@aws-cdk/aws-ec2"
 import {
+  ContainerImage,
   Ec2TaskDefinition,
   FargateTaskDefinition,
   NetworkMode,
@@ -81,6 +82,23 @@ describe("MackerelContainerAgentDefinition", () => {
         {
           apiKey: "keep-my-secret",
           hostStatusOnStart: MackerelHostStatus.Working,
+          taskDefinition,
+        }
+      )
+      expect(stack.toCloudFormation()).toMatchSnapshot()
+    })
+
+    test("with customImage", () => {
+      const stack = new Stack()
+      const taskDefinition = new Ec2TaskDefinition(stack, "TaskDefinition", {})
+      const container = new MackerelContainerAgentDefinition(
+        stack,
+        "mackerel-container-agent",
+        {
+          apiKey: "keep-my-secret",
+          image: ContainerImage.fromDockerHub(
+            "somebody/some-custom-agent-image"
+          ),
           taskDefinition,
         }
       )

--- a/src/mackerel-container-agent-definition.ts
+++ b/src/mackerel-container-agent-definition.ts
@@ -22,6 +22,7 @@ export interface Props
   ignoreContainer?: string
   hostStatusOnStart?: MackerelHostStatus
   generation?: AmazonLinuxGeneration
+  image?: ContainerImage
 }
 
 export class MackerelContainerAgentDefinition extends ContainerDefinition {
@@ -32,6 +33,7 @@ export class MackerelContainerAgentDefinition extends ContainerDefinition {
       ignoreContainer,
       hostStatusOnStart,
       generation,
+      image,
       taskDefinition,
       ...restProps
     } = props
@@ -61,12 +63,14 @@ export class MackerelContainerAgentDefinition extends ContainerDefinition {
       environment.MACKEREL_HOST_STATUS_ON_START = hostStatusOnStart
     }
 
+    const containerImage =
+      image ||
+      ContainerImage.fromDockerHub("mackerel/mackerel-container-agent:latest")
+
     super(parent, id, {
       ...restProps,
       environment,
-      image: ContainerImage.fromDockerHub(
-        "mackerel/mackerel-container-agent:latest"
-      ),
+      image: containerImage,
       taskDefinition,
     })
 


### PR DESCRIPTION
Implements #19 

Add `image` prop to `@aereal/cdk-mackerel-container-agent.Props`, so that users can specify custom-built container-agent image.
This p-r does not change default behavior, which uses `ContainerImage.fromDockerHub("mackerel/mackerel-container-agent:latest")`.