### PR TITLE
Support using custom docker image

### DIFF
--- a/src/__snapshots__/mackerel-container-agent-definition.test.ts.snap
+++ b/src/__snapshots__/mackerel-container-agent-definition.test.ts.snap
@@ -226,6 +226,154 @@ Object {
 }
 `;
 
+exports[`MackerelContainerAgentDefinition EC2 with \`plugins\` image 1`] = `
+Object {
+  "Resources": Object {
+    "TaskDefinitionB36D86D9": Object {
+      "Properties": Object {
+        "ContainerDefinitions": Array [
+          Object {
+            "Environment": Array [
+              Object {
+                "Name": "MACKEREL_APIKEY",
+                "Value": "keep-my-secret",
+              },
+              Object {
+                "Name": "MACKEREL_CONTAINER_PLATFORM",
+                "Value": "ecs",
+              },
+            ],
+            "Essential": true,
+            "Image": "mackerel/mackerel-container-agent:plugins",
+            "Links": Array [],
+            "Memory": 128,
+            "MountPoints": Array [],
+            "Name": "mackerel-container-agent",
+            "PortMappings": Array [],
+            "Ulimits": Array [],
+            "VolumesFrom": Array [],
+          },
+        ],
+        "Family": "TaskDefinition",
+        "NetworkMode": "bridge",
+        "RequiresCompatibilities": Array [
+          "EC2",
+        ],
+        "TaskRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "TaskDefinitionTaskRoleFD40A61D",
+            "Arn",
+          ],
+        },
+        "Volumes": Array [],
+      },
+      "Type": "AWS::ECS::TaskDefinition",
+    },
+    "TaskDefinitionTaskRoleFD40A61D": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "ecs-tasks.",
+                      Object {
+                        "Ref": "AWS::URLSuffix",
+                      },
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+  },
+}
+`;
+
+exports[`MackerelContainerAgentDefinition EC2 with customImage 1`] = `
+Object {
+  "Resources": Object {
+    "TaskDefinitionB36D86D9": Object {
+      "Properties": Object {
+        "ContainerDefinitions": Array [
+          Object {
+            "Environment": Array [
+              Object {
+                "Name": "MACKEREL_APIKEY",
+                "Value": "keep-my-secret",
+              },
+              Object {
+                "Name": "MACKEREL_CONTAINER_PLATFORM",
+                "Value": "ecs",
+              },
+            ],
+            "Essential": true,
+            "Image": "somebody/some-custom-agent-image",
+            "Links": Array [],
+            "Memory": 128,
+            "MountPoints": Array [],
+            "Name": "mackerel-container-agent",
+            "PortMappings": Array [],
+            "Ulimits": Array [],
+            "VolumesFrom": Array [],
+          },
+        ],
+        "Family": "TaskDefinition",
+        "NetworkMode": "bridge",
+        "RequiresCompatibilities": Array [
+          "EC2",
+        ],
+        "TaskRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "TaskDefinitionTaskRoleFD40A61D",
+            "Arn",
+          ],
+        },
+        "Volumes": Array [],
+      },
+      "Type": "AWS::ECS::TaskDefinition",
+    },
+    "TaskDefinitionTaskRoleFD40A61D": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "ecs-tasks.",
+                      Object {
+                        "Ref": "AWS::URLSuffix",
+                      },
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+  },
+}
+`;
+
 exports[`MackerelContainerAgentDefinition EC2 with hostStatusOnStart 1`] = `
 Object {
   "Resources": Object {

--- a/src/mackerel-container-agent-definition.test.ts
+++ b/src/mackerel-container-agent-definition.test.ts
@@ -1,11 +1,15 @@
 import { SynthUtils } from "@aws-cdk/assert"
 import {
+  ContainerImage,
   Ec2TaskDefinition,
   FargateTaskDefinition,
   NetworkMode,
 } from "@aws-cdk/aws-ecs"
 import { Stack } from "@aws-cdk/cdk"
-import { MackerelContainerAgentDefinition } from "./mackerel-container-agent-definition"
+import {
+  MackerelContainerAgentDefinition,
+  MackerelContainerAgentImage,
+} from "./mackerel-container-agent-definition"
 import { MackerelHostStatus } from "./types"
 
 describe("MackerelContainerAgentDefinition", () => {
@@ -66,6 +70,38 @@ describe("MackerelContainerAgentDefinition", () => {
         {
           apiKey: "keep-my-secret",
           hostStatusOnStart: MackerelHostStatus.Working,
+          taskDefinition,
+        }
+      )
+      expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot()
+    })
+
+    test("with customImage", () => {
+      const stack = new Stack()
+      const taskDefinition = new Ec2TaskDefinition(stack, "TaskDefinition", {})
+      const container = new MackerelContainerAgentDefinition(
+        stack,
+        "mackerel-container-agent",
+        {
+          apiKey: "keep-my-secret",
+          image: ContainerImage.fromRegistry(
+            "somebody/some-custom-agent-image"
+          ),
+          taskDefinition,
+        }
+      )
+      expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot()
+    })
+
+    test("with `plugins` image", () => {
+      const stack = new Stack()
+      const taskDefinition = new Ec2TaskDefinition(stack, "TaskDefinition", {})
+      const container = new MackerelContainerAgentDefinition(
+        stack,
+        "mackerel-container-agent",
+        {
+          apiKey: "keep-my-secret",
+          image: MackerelContainerAgentImage.Plugins,
           taskDefinition,
         }
       )

--- a/src/mackerel-container-agent-definition.ts
+++ b/src/mackerel-container-agent-definition.ts
@@ -1,4 +1,3 @@
-import { AmazonLinuxGeneration } from "@aws-cdk/aws-ec2"
 import {
   ContainerDefinition,
   ContainerDefinitionProps,
@@ -16,6 +15,16 @@ export interface Props extends Omit<ContainerDefinitionProps, "image"> {
   roles?: ReadonlyArray<ServiceRole>
   ignoreContainer?: string
   hostStatusOnStart?: MackerelHostStatus
+  image?: ContainerImage
+}
+
+export const MackerelContainerAgentImage = {
+  Latest: ContainerImage.fromRegistry(
+    "mackerel/mackerel-container-agent:latest"
+  ),
+  Plugins: ContainerImage.fromRegistry(
+    "mackerel/mackerel-container-agent:plugins"
+  ),
 }
 
 export class MackerelContainerAgentDefinition extends ContainerDefinition {
@@ -25,6 +34,7 @@ export class MackerelContainerAgentDefinition extends ContainerDefinition {
       roles,
       ignoreContainer,
       hostStatusOnStart,
+      image,
       taskDefinition,
       ...restProps
     } = props
@@ -34,6 +44,8 @@ export class MackerelContainerAgentDefinition extends ContainerDefinition {
       MACKEREL_APIKEY: apiKey,
       MACKEREL_CONTAINER_PLATFORM: "ecs",
     }
+
+    const containerImage = image || MackerelContainerAgentImage.Latest
 
     if (roles) {
       environment.MACKEREL_ROLES = roles
@@ -53,9 +65,7 @@ export class MackerelContainerAgentDefinition extends ContainerDefinition {
       memoryLimitMiB: 128,
       ...restProps,
       environment,
-      image: ContainerImage.fromRegistry(
-        "mackerel/mackerel-container-agent:latest"
-      ),
+      image: containerImage,
       taskDefinition,
     })
   }

--- a/src/mackerel-container-agent-definition.ts
+++ b/src/mackerel-container-agent-definition.ts
@@ -11,11 +11,7 @@ import {
   ServiceRole,
 } from "./types"
 
-export interface Props
-  extends Pick<
-    ContainerDefinitionProps,
-    Exclude<keyof ContainerDefinitionProps, "image">
-  > {
+export interface Props extends Omit<ContainerDefinitionProps, "image"> {
   apiKey: string
   roles?: ReadonlyArray<ServiceRole>
   ignoreContainer?: string


### PR DESCRIPTION
was #22

Also I added `MackerelContainerAgentImage.Latest` and `MackerelContainerAgentImage.Plugins`. Users just want to use official plugins can use `Plugins` at docker image specification.