### PR TITLE
pass MACKEREL_APIKEY as secrets instead of (raw) environment variables

### DIFF
--- a/src/__snapshots__/mackerel-container-agent-definition.test.ts.snap
+++ b/src/__snapshots__/mackerel-container-agent-definition.test.ts.snap
@@ -9,10 +9,6 @@ Object {
           Object {
             "Environment": Array [
               Object {
-                "Name": "MACKEREL_APIKEY",
-                "Value": "keep-my-secret",
-              },
-              Object {
                 "Name": "MACKEREL_CONTAINER_PLATFORM",
                 "Value": "ecs",
               },
@@ -21,8 +17,20 @@ Object {
             "Image": "mackerel/mackerel-container-agent:latest",
             "Memory": 128,
             "Name": "mackerel-container-agent",
+            "Secrets": Array [
+              Object {
+                "Name": "MACKEREL_APIKEY",
+                "ValueFrom": "dummy-arn",
+              },
+            ],
           },
         ],
+        "ExecutionRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "TaskDefinitionExecutionRole8D61C2FB",
+            "Arn",
+          ],
+        },
         "Family": "TaskDefinition",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": Array [
@@ -36,6 +44,44 @@ Object {
         },
       },
       "Type": "AWS::ECS::TaskDefinition",
+    },
+    "TaskDefinitionExecutionRole8D61C2FB": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "TaskDefinitionExecutionRoleDefaultPolicy1F3406F5": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "secretsmanager:GetSecretValue",
+              "Effect": "Allow",
+              "Resource": "dummy-arn",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "TaskDefinitionExecutionRoleDefaultPolicy1F3406F5",
+        "Roles": Array [
+          Object {
+            "Ref": "TaskDefinitionExecutionRole8D61C2FB",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "TaskDefinitionTaskRoleFD40A61D": Object {
       "Properties": Object {
@@ -67,6 +113,110 @@ Object {
           Object {
             "Environment": Array [
               Object {
+                "Name": "MACKEREL_CONTAINER_PLATFORM",
+                "Value": "ecs",
+              },
+            ],
+            "Essential": true,
+            "Image": "mackerel/mackerel-container-agent:latest",
+            "Memory": 128,
+            "Name": "mackerel-container-agent",
+            "Secrets": Array [
+              Object {
+                "Name": "MACKEREL_APIKEY",
+                "ValueFrom": "dummy-arn",
+              },
+            ],
+          },
+        ],
+        "ExecutionRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "TaskDefinitionExecutionRole8D61C2FB",
+            "Arn",
+          ],
+        },
+        "Family": "TaskDefinition",
+        "NetworkMode": "bridge",
+        "RequiresCompatibilities": Array [
+          "EC2",
+        ],
+        "TaskRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "TaskDefinitionTaskRoleFD40A61D",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ECS::TaskDefinition",
+    },
+    "TaskDefinitionExecutionRole8D61C2FB": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "TaskDefinitionExecutionRoleDefaultPolicy1F3406F5": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "secretsmanager:GetSecretValue",
+              "Effect": "Allow",
+              "Resource": "dummy-arn",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "TaskDefinitionExecutionRoleDefaultPolicy1F3406F5",
+        "Roles": Array [
+          Object {
+            "Ref": "TaskDefinitionExecutionRole8D61C2FB",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "TaskDefinitionTaskRoleFD40A61D": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+  },
+}
+`;
+
+exports[`MackerelContainerAgentDefinition EC2 pass unsafeBareAPIKey 1`] = `
+Object {
+  "Resources": Object {
+    "TaskDefinitionB36D86D9": Object {
+      "Properties": Object {
+        "ContainerDefinitions": Array [
+          Object {
+            "Environment": Array [
+              Object {
                 "Name": "MACKEREL_APIKEY",
                 "Value": "keep-my-secret",
               },
@@ -79,6 +229,7 @@ Object {
             "Image": "mackerel/mackerel-container-agent:latest",
             "Memory": 128,
             "Name": "mackerel-container-agent",
+            "Secrets": Array [],
           },
         ],
         "Family": "TaskDefinition",
@@ -125,10 +276,6 @@ Object {
           Object {
             "Environment": Array [
               Object {
-                "Name": "MACKEREL_APIKEY",
-                "Value": "keep-my-secret",
-              },
-              Object {
                 "Name": "MACKEREL_CONTAINER_PLATFORM",
                 "Value": "ecs",
               },
@@ -141,8 +288,20 @@ Object {
             "Image": "mackerel/mackerel-container-agent:latest",
             "Memory": 128,
             "Name": "mackerel-container-agent",
+            "Secrets": Array [
+              Object {
+                "Name": "MACKEREL_APIKEY",
+                "ValueFrom": "dummy-arn",
+              },
+            ],
           },
         ],
+        "ExecutionRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "TaskDefinitionExecutionRole8D61C2FB",
+            "Arn",
+          ],
+        },
         "Family": "TaskDefinition",
         "NetworkMode": "bridge",
         "RequiresCompatibilities": Array [
@@ -156,6 +315,44 @@ Object {
         },
       },
       "Type": "AWS::ECS::TaskDefinition",
+    },
+    "TaskDefinitionExecutionRole8D61C2FB": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "TaskDefinitionExecutionRoleDefaultPolicy1F3406F5": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "secretsmanager:GetSecretValue",
+              "Effect": "Allow",
+              "Resource": "dummy-arn",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "TaskDefinitionExecutionRoleDefaultPolicy1F3406F5",
+        "Roles": Array [
+          Object {
+            "Ref": "TaskDefinitionExecutionRole8D61C2FB",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "TaskDefinitionTaskRoleFD40A61D": Object {
       "Properties": Object {
@@ -187,10 +384,6 @@ Object {
           Object {
             "Environment": Array [
               Object {
-                "Name": "MACKEREL_APIKEY",
-                "Value": "keep-my-secret",
-              },
-              Object {
                 "Name": "MACKEREL_CONTAINER_PLATFORM",
                 "Value": "ecs",
               },
@@ -199,8 +392,20 @@ Object {
             "Image": "mackerel/mackerel-container-agent:plugins",
             "Memory": 128,
             "Name": "mackerel-container-agent",
+            "Secrets": Array [
+              Object {
+                "Name": "MACKEREL_APIKEY",
+                "ValueFrom": "dummy-arn",
+              },
+            ],
           },
         ],
+        "ExecutionRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "TaskDefinitionExecutionRole8D61C2FB",
+            "Arn",
+          ],
+        },
         "Family": "TaskDefinition",
         "NetworkMode": "bridge",
         "RequiresCompatibilities": Array [
@@ -214,6 +419,44 @@ Object {
         },
       },
       "Type": "AWS::ECS::TaskDefinition",
+    },
+    "TaskDefinitionExecutionRole8D61C2FB": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "TaskDefinitionExecutionRoleDefaultPolicy1F3406F5": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "secretsmanager:GetSecretValue",
+              "Effect": "Allow",
+              "Resource": "dummy-arn",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "TaskDefinitionExecutionRoleDefaultPolicy1F3406F5",
+        "Roles": Array [
+          Object {
+            "Ref": "TaskDefinitionExecutionRole8D61C2FB",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "TaskDefinitionTaskRoleFD40A61D": Object {
       "Properties": Object {
@@ -245,10 +488,6 @@ Object {
           Object {
             "Environment": Array [
               Object {
-                "Name": "MACKEREL_APIKEY",
-                "Value": "keep-my-secret",
-              },
-              Object {
                 "Name": "MACKEREL_CONTAINER_PLATFORM",
                 "Value": "ecs",
               },
@@ -257,8 +496,20 @@ Object {
             "Image": "somebody/some-custom-agent-image",
             "Memory": 128,
             "Name": "mackerel-container-agent",
+            "Secrets": Array [
+              Object {
+                "Name": "MACKEREL_APIKEY",
+                "ValueFrom": "dummy-arn",
+              },
+            ],
           },
         ],
+        "ExecutionRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "TaskDefinitionExecutionRole8D61C2FB",
+            "Arn",
+          ],
+        },
         "Family": "TaskDefinition",
         "NetworkMode": "bridge",
         "RequiresCompatibilities": Array [
@@ -272,6 +523,44 @@ Object {
         },
       },
       "Type": "AWS::ECS::TaskDefinition",
+    },
+    "TaskDefinitionExecutionRole8D61C2FB": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "TaskDefinitionExecutionRoleDefaultPolicy1F3406F5": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "secretsmanager:GetSecretValue",
+              "Effect": "Allow",
+              "Resource": "dummy-arn",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "TaskDefinitionExecutionRoleDefaultPolicy1F3406F5",
+        "Roles": Array [
+          Object {
+            "Ref": "TaskDefinitionExecutionRole8D61C2FB",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "TaskDefinitionTaskRoleFD40A61D": Object {
       "Properties": Object {
@@ -303,10 +592,6 @@ Object {
           Object {
             "Environment": Array [
               Object {
-                "Name": "MACKEREL_APIKEY",
-                "Value": "keep-my-secret",
-              },
-              Object {
                 "Name": "MACKEREL_CONTAINER_PLATFORM",
                 "Value": "ecs",
               },
@@ -319,8 +604,20 @@ Object {
             "Image": "mackerel/mackerel-container-agent:latest",
             "Memory": 128,
             "Name": "mackerel-container-agent",
+            "Secrets": Array [
+              Object {
+                "Name": "MACKEREL_APIKEY",
+                "ValueFrom": "dummy-arn",
+              },
+            ],
           },
         ],
+        "ExecutionRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "TaskDefinitionExecutionRole8D61C2FB",
+            "Arn",
+          ],
+        },
         "Family": "TaskDefinition",
         "NetworkMode": "bridge",
         "RequiresCompatibilities": Array [
@@ -334,6 +631,44 @@ Object {
         },
       },
       "Type": "AWS::ECS::TaskDefinition",
+    },
+    "TaskDefinitionExecutionRole8D61C2FB": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "TaskDefinitionExecutionRoleDefaultPolicy1F3406F5": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "secretsmanager:GetSecretValue",
+              "Effect": "Allow",
+              "Resource": "dummy-arn",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "TaskDefinitionExecutionRoleDefaultPolicy1F3406F5",
+        "Roles": Array [
+          Object {
+            "Ref": "TaskDefinitionExecutionRole8D61C2FB",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "TaskDefinitionTaskRoleFD40A61D": Object {
       "Properties": Object {
@@ -365,10 +700,6 @@ Object {
           Object {
             "Environment": Array [
               Object {
-                "Name": "MACKEREL_APIKEY",
-                "Value": "keep-my-secret",
-              },
-              Object {
                 "Name": "MACKEREL_CONTAINER_PLATFORM",
                 "Value": "ecs",
               },
@@ -381,8 +712,20 @@ Object {
             "Image": "mackerel/mackerel-container-agent:latest",
             "Memory": 128,
             "Name": "mackerel-container-agent",
+            "Secrets": Array [
+              Object {
+                "Name": "MACKEREL_APIKEY",
+                "ValueFrom": "dummy-arn",
+              },
+            ],
           },
         ],
+        "ExecutionRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "TaskDefinitionExecutionRole8D61C2FB",
+            "Arn",
+          ],
+        },
         "Family": "TaskDefinition",
         "NetworkMode": "bridge",
         "RequiresCompatibilities": Array [
@@ -396,6 +739,44 @@ Object {
         },
       },
       "Type": "AWS::ECS::TaskDefinition",
+    },
+    "TaskDefinitionExecutionRole8D61C2FB": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "TaskDefinitionExecutionRoleDefaultPolicy1F3406F5": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "secretsmanager:GetSecretValue",
+              "Effect": "Allow",
+              "Resource": "dummy-arn",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "TaskDefinitionExecutionRoleDefaultPolicy1F3406F5",
+        "Roles": Array [
+          Object {
+            "Ref": "TaskDefinitionExecutionRole8D61C2FB",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "TaskDefinitionTaskRoleFD40A61D": Object {
       "Properties": Object {
@@ -427,10 +808,6 @@ Object {
           Object {
             "Environment": Array [
               Object {
-                "Name": "MACKEREL_APIKEY",
-                "Value": "keep-my-secret",
-              },
-              Object {
                 "Name": "MACKEREL_CONTAINER_PLATFORM",
                 "Value": "ecs",
               },
@@ -439,9 +816,21 @@ Object {
             "Image": "mackerel/mackerel-container-agent:latest",
             "Memory": 128,
             "Name": "mackerel-container-agent",
+            "Secrets": Array [
+              Object {
+                "Name": "MACKEREL_APIKEY",
+                "ValueFrom": "dummy-arn",
+              },
+            ],
           },
         ],
         "Cpu": "256",
+        "ExecutionRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "TaskDefinitionExecutionRole8D61C2FB",
+            "Arn",
+          ],
+        },
         "Family": "TaskDefinition",
         "Memory": "512",
         "NetworkMode": "awsvpc",
@@ -456,6 +845,44 @@ Object {
         },
       },
       "Type": "AWS::ECS::TaskDefinition",
+    },
+    "TaskDefinitionExecutionRole8D61C2FB": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "TaskDefinitionExecutionRoleDefaultPolicy1F3406F5": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "secretsmanager:GetSecretValue",
+              "Effect": "Allow",
+              "Resource": "dummy-arn",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "TaskDefinitionExecutionRoleDefaultPolicy1F3406F5",
+        "Roles": Array [
+          Object {
+            "Ref": "TaskDefinitionExecutionRole8D61C2FB",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "TaskDefinitionTaskRoleFD40A61D": Object {
       "Properties": Object {

--- a/src/mackerel-container-agent-definition.test.ts
+++ b/src/mackerel-container-agent-definition.test.ts
@@ -1,9 +1,11 @@
 import { SynthUtils } from "@aws-cdk/assert";
+import { Secret as SecretsManagerSecret } from "@aws-cdk/aws-secretsmanager";
 import {
   ContainerImage,
   Ec2TaskDefinition,
   FargateTaskDefinition,
-  NetworkMode
+  NetworkMode,
+  Secret
 } from "@aws-cdk/aws-ecs";
 import { Stack } from "@aws-cdk/core";
 import {
@@ -13,8 +15,80 @@ import {
 import { MackerelHostStatus } from "./types";
 
 describe("MackerelContainerAgentDefinition", () => {
+  describe("Common", () => {
+    const errorMessage =
+      "Either apiKey or unsafeBareAPIKey must be passed (apiKey as Secret highly recommended)";
+
+    test("neither apiKey nor unsafeBareAPIKey passed", () => {
+      const stack = new Stack();
+      const taskDefinition = new Ec2TaskDefinition(stack, "TaskDefinition", {});
+      expect(
+        () =>
+          new MackerelContainerAgentDefinition(
+            stack,
+            "mackerel-container-agent",
+            { taskDefinition }
+          )
+      ).toThrowError(errorMessage);
+    });
+
+    test("only apiKey passed", () => {
+      const stack = new Stack();
+      const taskDefinition = new Ec2TaskDefinition(stack, "TaskDefinition", {});
+      expect(
+        () =>
+          new MackerelContainerAgentDefinition(
+            stack,
+            "mackerel-container-agent",
+            {
+              taskDefinition,
+              apiKey: Secret.fromSecretsManager(
+                SecretsManagerSecret.fromSecretArn(
+                  stack,
+                  "ImportedSecret",
+                  "dummy-arn"
+                )
+              )
+            }
+          )
+      ).not.toThrowError(errorMessage);
+    });
+
+    test("only unsafeBareAPIKey passed", () => {
+      const stack = new Stack();
+      const taskDefinition = new Ec2TaskDefinition(stack, "TaskDefinition", {});
+      expect(
+        () =>
+          new MackerelContainerAgentDefinition(
+            stack,
+            "mackerel-container-agent",
+            {
+              taskDefinition,
+              unsafeBareAPIKey: "keep-my-secret"
+            }
+          )
+      ).not.toThrowError(errorMessage);
+    });
+  });
+
   describe("EC2", () => {
     test("add to task definition with only required props", () => {
+      const stack = new Stack();
+      const taskDefinition = new Ec2TaskDefinition(stack, "TaskDefinition", {});
+      new MackerelContainerAgentDefinition(stack, "mackerel-container-agent", {
+        apiKey: Secret.fromSecretsManager(
+          SecretsManagerSecret.fromSecretArn(
+            stack,
+            "ImportedSecret",
+            "dummy-arn"
+          )
+        ),
+        taskDefinition
+      });
+      expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
+    });
+
+    test("pass unsafeBareAPIKey", () => {
       const stack = new Stack();
       const taskDefinition = new Ec2TaskDefinition(stack, "TaskDefinition", {});
       const container = new MackerelContainerAgentDefinition(
@@ -35,7 +109,13 @@ describe("MackerelContainerAgentDefinition", () => {
         stack,
         "mackerel-container-agent",
         {
-          unsafeBareAPIKey: "keep-my-secret",
+          apiKey: Secret.fromSecretsManager(
+            SecretsManagerSecret.fromSecretArn(
+              stack,
+              "ImportedSecret",
+              "dummy-arn"
+            )
+          ),
           roles: [
             { service: "My-service", role: "db" },
             { service: "My-service", role: "proxy" }
@@ -53,7 +133,13 @@ describe("MackerelContainerAgentDefinition", () => {
         stack,
         "mackerel-container-agent",
         {
-          unsafeBareAPIKey: "keep-my-secret",
+          apiKey: Secret.fromSecretsManager(
+            SecretsManagerSecret.fromSecretArn(
+              stack,
+              "ImportedSecret",
+              "dummy-arn"
+            )
+          ),
           ignoreContainer: "(mackerel|xray)",
           taskDefinition
         }
@@ -68,7 +154,13 @@ describe("MackerelContainerAgentDefinition", () => {
         stack,
         "mackerel-container-agent",
         {
-          unsafeBareAPIKey: "keep-my-secret",
+          apiKey: Secret.fromSecretsManager(
+            SecretsManagerSecret.fromSecretArn(
+              stack,
+              "ImportedSecret",
+              "dummy-arn"
+            )
+          ),
           hostStatusOnStart: MackerelHostStatus.Working,
           taskDefinition
         }
@@ -83,7 +175,13 @@ describe("MackerelContainerAgentDefinition", () => {
         stack,
         "mackerel-container-agent",
         {
-          unsafeBareAPIKey: "keep-my-secret",
+          apiKey: Secret.fromSecretsManager(
+            SecretsManagerSecret.fromSecretArn(
+              stack,
+              "ImportedSecret",
+              "dummy-arn"
+            )
+          ),
           image: ContainerImage.fromRegistry(
             "somebody/some-custom-agent-image"
           ),
@@ -100,7 +198,13 @@ describe("MackerelContainerAgentDefinition", () => {
         stack,
         "mackerel-container-agent",
         {
-          unsafeBareAPIKey: "keep-my-secret",
+          apiKey: Secret.fromSecretsManager(
+            SecretsManagerSecret.fromSecretArn(
+              stack,
+              "ImportedSecret",
+              "dummy-arn"
+            )
+          ),
           image: MackerelContainerAgentImage.Plugins,
           taskDefinition
         }
@@ -119,7 +223,13 @@ describe("MackerelContainerAgentDefinition", () => {
         stack,
         "mackerel-container-agent",
         {
-          unsafeBareAPIKey: "keep-my-secret",
+          apiKey: Secret.fromSecretsManager(
+            SecretsManagerSecret.fromSecretArn(
+              stack,
+              "ImportedSecret",
+              "dummy-arn"
+            )
+          ),
           taskDefinition
         }
       );
@@ -140,7 +250,13 @@ describe("MackerelContainerAgentDefinition", () => {
         stack,
         "mackerel-container-agent",
         {
-          unsafeBareAPIKey: "keep-my-secret",
+          apiKey: Secret.fromSecretsManager(
+            SecretsManagerSecret.fromSecretArn(
+              stack,
+              "ImportedSecret",
+              "dummy-arn"
+            )
+          ),
           taskDefinition
         }
       );

--- a/src/mackerel-container-agent-definition.test.ts
+++ b/src/mackerel-container-agent-definition.test.ts
@@ -32,6 +32,31 @@ describe("MackerelContainerAgentDefinition", () => {
       ).toThrowError(errorMessage);
     });
 
+    test("both passed", () => {
+      const stack = new Stack();
+      const taskDefinition = new Ec2TaskDefinition(stack, "TaskDefinition", {});
+      expect(
+        () =>
+          new MackerelContainerAgentDefinition(
+            stack,
+            "mackerel-container-agent",
+            {
+              taskDefinition,
+              apiKey: Secret.fromSecretsManager(
+                SecretsManagerSecret.fromSecretArn(
+                  stack,
+                  "ImportedSecret",
+                  "dummy-arn"
+                )
+              ),
+              unsafeBareAPIKey: "keep-my-secret"
+            }
+          )
+      ).toThrowError(
+        "Just one of either apiKey unsafeBareAPIKey can be passed"
+      );
+    });
+
     test("only apiKey passed", () => {
       const stack = new Stack();
       const taskDefinition = new Ec2TaskDefinition(stack, "TaskDefinition", {});

--- a/src/mackerel-container-agent-definition.test.ts
+++ b/src/mackerel-container-agent-definition.test.ts
@@ -21,7 +21,7 @@ describe("MackerelContainerAgentDefinition", () => {
         stack,
         "mackerel-container-agent",
         {
-          apiKey: "keep-my-secret",
+          unsafeBareAPIKey: "keep-my-secret",
           taskDefinition
         }
       );
@@ -35,7 +35,7 @@ describe("MackerelContainerAgentDefinition", () => {
         stack,
         "mackerel-container-agent",
         {
-          apiKey: "keep-my-secret",
+          unsafeBareAPIKey: "keep-my-secret",
           roles: [
             { service: "My-service", role: "db" },
             { service: "My-service", role: "proxy" }
@@ -53,7 +53,7 @@ describe("MackerelContainerAgentDefinition", () => {
         stack,
         "mackerel-container-agent",
         {
-          apiKey: "keep-my-secret",
+          unsafeBareAPIKey: "keep-my-secret",
           ignoreContainer: "(mackerel|xray)",
           taskDefinition
         }
@@ -68,7 +68,7 @@ describe("MackerelContainerAgentDefinition", () => {
         stack,
         "mackerel-container-agent",
         {
-          apiKey: "keep-my-secret",
+          unsafeBareAPIKey: "keep-my-secret",
           hostStatusOnStart: MackerelHostStatus.Working,
           taskDefinition
         }
@@ -83,7 +83,7 @@ describe("MackerelContainerAgentDefinition", () => {
         stack,
         "mackerel-container-agent",
         {
-          apiKey: "keep-my-secret",
+          unsafeBareAPIKey: "keep-my-secret",
           image: ContainerImage.fromRegistry(
             "somebody/some-custom-agent-image"
           ),
@@ -100,7 +100,7 @@ describe("MackerelContainerAgentDefinition", () => {
         stack,
         "mackerel-container-agent",
         {
-          apiKey: "keep-my-secret",
+          unsafeBareAPIKey: "keep-my-secret",
           image: MackerelContainerAgentImage.Plugins,
           taskDefinition
         }
@@ -119,7 +119,7 @@ describe("MackerelContainerAgentDefinition", () => {
         stack,
         "mackerel-container-agent",
         {
-          apiKey: "keep-my-secret",
+          unsafeBareAPIKey: "keep-my-secret",
           taskDefinition
         }
       );
@@ -140,7 +140,7 @@ describe("MackerelContainerAgentDefinition", () => {
         stack,
         "mackerel-container-agent",
         {
-          apiKey: "keep-my-secret",
+          unsafeBareAPIKey: "keep-my-secret",
           taskDefinition
         }
       );

--- a/src/mackerel-container-agent-definition.ts
+++ b/src/mackerel-container-agent-definition.ts
@@ -4,14 +4,10 @@ import {
   ContainerImage
 } from "@aws-cdk/aws-ecs";
 import { Construct } from "@aws-cdk/core";
-import {
-  MackerelContainerPlatform,
-  MackerelHostStatus,
-  ServiceRole
-} from "./types";
+import { MackerelHostStatus, ServiceRole } from "./types";
 
 export interface Props extends Omit<ContainerDefinitionProps, "image"> {
-  apiKey: string;
+  unsafeBareAPIKey: string;
   roles?: readonly ServiceRole[];
   ignoreContainer?: string;
   hostStatusOnStart?: MackerelHostStatus;
@@ -30,7 +26,7 @@ export const MackerelContainerAgentImage = {
 export class MackerelContainerAgentDefinition extends ContainerDefinition {
   constructor(parent: Construct, id: string, props: Props) {
     const {
-      apiKey,
+      unsafeBareAPIKey,
       roles,
       ignoreContainer,
       hostStatusOnStart,
@@ -41,7 +37,7 @@ export class MackerelContainerAgentDefinition extends ContainerDefinition {
 
     const environment: Record<string, string> = {
       ...(props && props.environment ? props.environment : {}),
-      MACKEREL_APIKEY: apiKey,
+      MACKEREL_APIKEY: unsafeBareAPIKey,
       MACKEREL_CONTAINER_PLATFORM: "ecs"
     };
 

--- a/src/mackerel-container-agent-definition.ts
+++ b/src/mackerel-container-agent-definition.ts
@@ -44,6 +44,12 @@ export class MackerelContainerAgentDefinition extends ContainerDefinition {
       );
     }
 
+    if (unsafeBareAPIKey !== undefined && apiKey !== undefined) {
+      throw new Error(
+        "Just one of either apiKey unsafeBareAPIKey can be passed"
+      );
+    }
+
     const environment: Record<string, string> = {
       ...(props && props.environment ? props.environment : {}),
       ...(unsafeBareAPIKey !== undefined

--- a/src/mackerel-container-agent-definition.ts
+++ b/src/mackerel-container-agent-definition.ts
@@ -2,7 +2,8 @@ import {
   ContainerDefinition,
   ContainerDefinitionProps,
   ContainerImage,
-  Secret
+  Secret,
+  Scope
 } from "@aws-cdk/aws-ecs";
 import { Construct } from "@aws-cdk/core";
 import { MackerelHostStatus, ServiceRole } from "./types";
@@ -89,5 +90,11 @@ export class MackerelContainerAgentDefinition extends ContainerDefinition {
       secrets,
       taskDefinition
     });
+
+    if (unsafeBareAPIKey !== undefined) {
+      this.node.addWarning(
+        "unsafeBareAPIKey is deprecated and will be removed at next major version. Please use apiKey: Secret"
+      );
+    }
   }
 }


### PR DESCRIPTION
roadmap (candidate)

- this major version (1.x.x)
  - :new: supports `apiKey: Secret` 
  - also supports (old `apiKey: string` →) `unsafeBareAPIKey: string`
- next major version
  - only supports `apiKey: Secret` 
  - discontinue supporting `unsafeBareAPIKey: string`